### PR TITLE
return media_id from iOS for GamingServices media uploads (#441)

### DIFF
--- a/UnitySDK/Assets/FacebookSDK/Plugins/Editor/Dependencies.xml
+++ b/UnitySDK/Assets/FacebookSDK/Plugins/Editor/Dependencies.xml
@@ -9,9 +9,9 @@
         <androidPackage spec="com.facebook.android:facebook-gamingservices:[6.2.0, 7)" />
     </androidPackages>
     <iosPods>
-        <iosPod name="FBSDKCoreKit" version="~> 6.2" />
-        <iosPod name="FBSDKLoginKit" version="~> 6.2" />
-        <iosPod name="FBSDKShareKit" version="~> 6.2" />
-        <iosPod name="FBSDKGamingServicesKit" version="~> 6.2" />
+        <iosPod name="FBSDKCoreKit" version="~> 6.5.2" />
+        <iosPod name="FBSDKLoginKit" version="~> 6.5.2" />
+        <iosPod name="FBSDKShareKit" version="~> 6.5.2" />
+        <iosPod name="FBSDKGamingServicesKit" version="~> 6.5.2" />
     </iosPods>
 </dependencies>

--- a/UnitySDK/Assets/FacebookSDK/SDK/Editor/iOS/FBUnityInterface.mm
+++ b/UnitySDK/Assets/FacebookSDK/SDK/Editor/iOS/FBUnityInterface.mm
@@ -522,14 +522,14 @@ extern "C" {
 
     [FBSDKGamingImageUploader
       uploadImageWithConfiguration:config
-      andCompletionHandler:^(BOOL success, NSError * _Nullable error) {
+      andResultCompletionHandler:^(BOOL success, id result, NSError * _Nullable error) {
         if (!success || error) {
           [FBUnityUtility sendErrorToUnity:FBUnityMessageName_OnUploadImageToMediaLibraryComplete
             error:error
             requestId:requestId];
         } else {
           [FBUnityUtility sendMessageToUnity:FBUnityMessageName_OnUploadImageToMediaLibraryComplete
-            userData:NULL
+            userData:@{@"id":result[@"id"]}
             requestId:requestId];
         }
     }];
@@ -551,14 +551,14 @@ extern "C" {
 
     [FBSDKGamingVideoUploader
       uploadVideoWithConfiguration:config
-      andCompletionHandler:^(BOOL success, NSError * _Nullable error) {
+      andResultCompletionHandler:^(BOOL success, id result, NSError * _Nullable error) {
         if (!success || error) {
           [FBUnityUtility sendErrorToUnity:FBUnityMessageName_OnUploadVideoToMediaLibraryComplete
             error:error
             requestId:requestId];
         } else {
           [FBUnityUtility sendMessageToUnity:FBUnityMessageName_OnUploadVideoToMediaLibraryComplete
-            userData:NULL
+            userData:@{@"id":result[@"id"]}
             requestId:requestId];
         }
     }];


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebook/facebook-sdk-for-unity/pull/441

Previously the iOS SDK didn't return the media id after uploading images/videos. Now that it does this wires the returned ID back to unity.

Reviewed By: dloomb

Differential Revision: D21605593

fbshipit-source-id: 6b6a1eb1e11ceafbf59c17b155005329279d2a66

Thanks for proposing a pull request!

To help us review the request, please complete the following:

- [x] sign [contributor license agreement](https://developers.facebook.com/opensource/cla)
- [x] I've ensured that all existing tests pass and added tests (when/where necessary)
- [x] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [x] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Describe what you accomplished in this pull request (for example, what happens before the change, and after the change)

## Test Plan

Test Plan: **Add your test plan here**
